### PR TITLE
Add support for specifying custom timestamp formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To change the way the `startTime` and `endTime` are formatted in `startTimeForma
 The formatter function shall accept a single argument as a number and return the value formatted as a string.
 
 ```javascript
-import { timestampFormatter } from "transcriptator/timestamp"
+import { timestampFormatter } from "transcriptator"
 
 function customFormatter(timestamp) {
     return timestamp.toString()

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ The `TranscriptFormat` enum defines the allowable transcript types supported by 
 
 The `Segment` type defines the segment/cue of the transcript.
 
+### Custom timestamp formatter
+
+To change the way the `startTime` and `endTime` are formatted in `startTimeFormatted` and `endTimeFormatted`, register a custom formatter to be used instead.
+The formatter function shall accept a single argument as a number and return the value formatted as a string.
+
+```javascript
+import { timestampFormatter } from "transcriptator/timestamp"
+
+function customFormatter(timestamp) {
+    return timestamp.toString()
+}
+
+timestampFormatter.registerCustomFormatter(customFormatter)
+```
+
 ## Supported File Formats
 
 ### SRT

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "test": "jest",
         "test:coverage": "yarn test --coverage",
         "tag": "npm version patch",
-        "publish": "yarn lint && yarn build && cd dist && npm publish"
+        "build-publish": "yarn lint && yarn build && cd dist && npm publish"
     },
     "repository": {
         "type": "git",

--- a/src/formats/html.ts
+++ b/src/formats/html.ts
@@ -1,6 +1,6 @@
 import { HTMLElement, parse } from "node-html-parser"
 
-import { formatTimestamp, parseTimestamp } from "../timestamp"
+import { parseTimestamp, timestampFormatter } from "../timestamp"
 import { Segment } from "../types"
 
 /**
@@ -98,9 +98,9 @@ const createSegmentFromSegmentPart = (
 
     const segment: Segment = {
         startTime,
-        startTimeFormatted: formatTimestamp(startTime),
+        startTimeFormatted: timestampFormatter.format(startTime),
         endTime: 0,
-        endTimeFormatted: formatTimestamp(0),
+        endTimeFormatted: timestampFormatter.format(0),
         speaker: calculatedSpeaker.replace(":", "").trimEnd(),
         body: segmentPart.text,
     }
@@ -150,7 +150,7 @@ const getSegmentsFromHTMLElements = (elements: Array<HTMLElement>): Array<Segmen
                 if (totalSegments > 0) {
                     outSegments[totalSegments - 1].endTime =
                         outSegments[totalSegments - 1].startTime + s.segment.startTime
-                    outSegments[totalSegments - 1].endTimeFormatted = formatTimestamp(
+                    outSegments[totalSegments - 1].endTimeFormatted = timestampFormatter.format(
                         outSegments[totalSegments - 1].endTime
                     )
                 }

--- a/src/formats/json.ts
+++ b/src/formats/json.ts
@@ -1,5 +1,5 @@
 import { parseSpeaker } from "../speaker"
-import { formatTimestamp } from "../timestamp"
+import { timestampFormatter } from "../timestamp"
 import { Segment } from "../types"
 
 /**
@@ -78,9 +78,9 @@ const parseDictSegmentsJSON = (data: JSONTranscript): Array<Segment> => {
     data.segments.forEach((segment) => {
         outSegments.push({
             startTime: segment.startTime,
-            startTimeFormatted: formatTimestamp(segment.startTime),
+            startTimeFormatted: timestampFormatter.format(segment.startTime),
             endTime: segment.endTime,
-            endTimeFormatted: formatTimestamp(segment.endTime),
+            endTimeFormatted: timestampFormatter.format(segment.endTime),
             speaker: segment.speaker,
             body: segment.body,
         })
@@ -126,9 +126,9 @@ const getSegmentFromSubtitle = (data: SubtitleSegment): Segment => {
         const endTime = data.end / 1000
         const segment: Segment = {
             startTime,
-            startTimeFormatted: formatTimestamp(startTime),
+            startTimeFormatted: timestampFormatter.format(startTime),
             endTime,
-            endTimeFormatted: formatTimestamp(endTime),
+            endTimeFormatted: timestampFormatter.format(endTime),
             speaker,
             body: message,
         }

--- a/src/formats/srt.ts
+++ b/src/formats/srt.ts
@@ -1,5 +1,5 @@
 import { parseSpeaker } from "../speaker"
-import { formatTimestamp, parseTimestamp } from "../timestamp"
+import { parseTimestamp, timestampFormatter } from "../timestamp"
 import { PATTERN_LINE_SEPARATOR, Segment } from "../types"
 
 /**
@@ -101,9 +101,9 @@ const createSegmentFromSRTLines = (
     const calculatedSpeaker = srtSegment.speaker ? srtSegment.speaker : lastSpeaker
     const segment: Segment = {
         startTime: srtSegment.startTime,
-        startTimeFormatted: formatTimestamp(srtSegment.startTime),
+        startTimeFormatted: timestampFormatter.format(srtSegment.startTime),
         endTime: srtSegment.endTime,
-        endTimeFormatted: formatTimestamp(srtSegment.endTime),
+        endTimeFormatted: timestampFormatter.format(srtSegment.endTime),
         speaker: calculatedSpeaker,
         body: srtSegment.body,
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ import { isSRT, parseSRT } from "./formats/srt"
 import { isVTT, parseVTT } from "./formats/vtt"
 import { Segment, TranscriptFormat } from "./types"
 
+export { Segment, TranscriptFormat } from "./types"
+export { timestampFormatter, FormatterCallback } from "./timestamp"
+
 /**
  * Regular Expression for detecting punctuation that should not be prefixed with a space
  */

--- a/src/timestamp.ts
+++ b/src/timestamp.ts
@@ -50,17 +50,81 @@ export const parseTimestamp = (value: string | number): number => {
 }
 
 /**
- * Format the timestamp number to a human readable string in the format HH:mm:SS.fff
- *
- * @param timestamp Time in seconds to format
- * @returns formatted timestamp string
+ * Timestamp formatter
  */
-export const formatTimestamp = (timestamp: number): string => {
-    const hours = String(Math.floor(timestamp / 3600)).padStart(2, "0")
-    const remaining = timestamp % 3600
-    const minutes = String(Math.floor(remaining / 60)).padStart(2, "0")
-    const seconds = String(Math.floor(remaining % 60)).padStart(2, "0")
-    const ms = String(Math.round((timestamp - Math.floor(timestamp)) * 1000)).padStart(3, "0")
-
-    return `${hours}:${minutes}:${seconds}.${ms}`
+export interface FormatterCallback {
+    (timestamp: number): string
 }
+
+/**
+ * Provides a way to convert numeric timestamp to a formatted string.
+ *
+ * A custom formatter may be registered.
+ * If one isn't registered, the default formatter will be used and the data will be formatted as HH:mm:SS.fff
+ */
+export class TimestampFormatter {
+    static _instance: TimestampFormatter
+
+    private customFormatter: FormatterCallback = undefined
+
+    /**
+     * Create the formatter
+     */
+    constructor() {
+        if (!TimestampFormatter._instance) {
+            TimestampFormatter._instance = this
+        }
+        // eslint-disable-next-line no-constructor-return
+        return TimestampFormatter._instance
+    }
+
+    /**
+     * Default formatter where the timestamp number is formatted to a human readable string in the format HH:mm:SS.fff
+     *
+     * @param timestamp Time in seconds to format
+     * @returns formatted timestamp string
+     */
+    private static defaultFormatter = (timestamp: number): string => {
+        const hours = String(Math.floor(timestamp / 3600)).padStart(2, "0")
+        const remaining = timestamp % 3600
+        const minutes = String(Math.floor(remaining / 60)).padStart(2, "0")
+        const seconds = String(Math.floor(remaining % 60)).padStart(2, "0")
+        const ms = String(Math.round((timestamp - Math.floor(timestamp)) * 1000)).padStart(3, "0")
+
+        return `${hours}:${minutes}:${seconds}.${ms}`
+    }
+
+    /**
+     * Format the timestamp to a human readable string.
+     *
+     * If a custom formatter has been registered, it will be used.
+     * If not, the default formatter is used and the data will be returned in the format HH:mm:SS.fff
+     *
+     * @param timestamp Time in seconds to format
+     * @returns formatted timestamp string
+     */
+    public format = (timestamp: number): string => {
+        if (this.customFormatter === undefined) {
+            return TimestampFormatter.defaultFormatter(timestamp)
+        }
+        return this.customFormatter(timestamp)
+    }
+
+    /**
+     * Register a custom timestamp formatter
+     *
+     * @param formatter function to call to format timestamp to string
+     */
+    public registerCustomFormatter = (formatter: FormatterCallback): void => {
+        this.customFormatter = formatter
+    }
+
+    /**
+     * Remove the custom formatter (if one registered)
+     */
+    public unregisterCustomFormatter = (): void => {
+        this.customFormatter = undefined
+    }
+}
+
+export const timestampFormatter = new TimestampFormatter()

--- a/test/timestamp.test.ts
+++ b/test/timestamp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "@jest/globals"
 
-import { formatTimestamp, parseTimestamp } from "../src/timestamp"
+import { parseTimestamp, TimestampFormatter, timestampFormatter } from "../src/timestamp"
 
 describe("Timestamp", () => {
     test.each<{
@@ -93,6 +93,23 @@ describe("Undefined timestamp", () => {
     })
 })
 
+/**
+ * Custom formatter
+ *
+ * @param timestamp Time in seconds to format
+ * @returns formatted timestamp string
+ */
+const customFormatter = (timestamp: number): string => {
+    return timestamp.toString()
+}
+
+test("Timestamp Formatter instances", () => {
+    timestampFormatter.registerCustomFormatter(customFormatter)
+    const second = new TimestampFormatter()
+    expect(timestampFormatter === second).toBe(true)
+    timestampFormatter.unregisterCustomFormatter()
+})
+
 describe("Format timestamp", () => {
     test.each<{
         data: number
@@ -115,6 +132,34 @@ describe("Format timestamp", () => {
             expected: "101:32:47.120",
         },
     ])("Format timestamp ($data)", ({ data, expected }) => {
-        expect(formatTimestamp(data)).toEqual(expected)
+        expect(timestampFormatter.format(data)).toEqual(expected)
+    })
+})
+
+describe("Custom formatter", () => {
+    test.each<{
+        data: number
+        expected: string
+    }>([
+        {
+            data: 0.78,
+            expected: "0.78",
+        },
+        {
+            data: 0.7248,
+            expected: "0.7248",
+        },
+        {
+            data: 3723.456,
+            expected: "3723.456",
+        },
+        {
+            data: 365567.12,
+            expected: "365567.12",
+        },
+    ])("Custom timestamp formatter ($data)", ({ data, expected }) => {
+        timestampFormatter.registerCustomFormatter(customFormatter)
+        expect(timestampFormatter.format(data)).toEqual(expected)
+        timestampFormatter.unregisterCustomFormatter()
     })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "esModuleInterop": true,
         "target": "es2020",
         "moduleResolution": "node",
-        "sourceMap": true,
+        "sourceMap": false,
         "outDir": "dist"
     },
     "include": ["src"],


### PR DESCRIPTION
When I try to use this, PyCharm complains that `registerCustomFormatter` is unresolved. I'm not sure if this is just a PyCharm issue or if I need to do something else.


Resolves #11